### PR TITLE
Allow manually usage of DioEventProcessor 

### DIFF
--- a/dio/lib/src/dio_event_processor.dart
+++ b/dio/lib/src/dio_event_processor.dart
@@ -13,7 +13,12 @@ class DioEventProcessor implements EventProcessor {
   static final _dioErrorType = (DioError).toString();
 
   /// This is an [EventProcessor], which improves crash reports of [DioError]s.
-  DioEventProcessor(this._options, this._maxRequestBodySize);
+  DioEventProcessor({
+    MaxRequestBodySize maxRequestBodySize = MaxRequestBodySize.never,
+    Hub? hub,
+    // ignore: invalid_use_of_internal_member
+  })  : _options = (hub ?? HubAdapter()).options,
+        _maxRequestBodySize = maxRequestBodySize;
 
   final SentryOptions _options;
   final MaxRequestBodySize _maxRequestBodySize;

--- a/dio/lib/src/sentry_dio_extension.dart
+++ b/dio/lib/src/sentry_dio_extension.dart
@@ -25,8 +25,16 @@ extension SentryDioExtension on Dio {
 
     // Add DioEventProcessor when it's not already present
     if (options.eventProcessors.whereType<DioEventProcessor>().isEmpty) {
+      options.addEventProcessor(
+        DioEventProcessor(
+          hub: hub,
+          maxRequestBodySize: maxRequestBodySize,
+        ),
+      );
+    }
+
+    if (!options.sdk.integrations.contains('sentry_dio')) {
       options.sdk.addIntegration('sentry_dio');
-      options.addEventProcessor(DioEventProcessor(options, maxRequestBodySize));
     }
 
     if (captureFailedRequests) {

--- a/dio/test/dio_event_processor_test.dart
+++ b/dio/test/dio_event_processor_test.dart
@@ -150,8 +150,8 @@ class Fixture {
 
   DioEventProcessor getSut({bool sendDefaultPii = false}) {
     return DioEventProcessor(
-      options..sendDefaultPii = sendDefaultPii,
-      MaxRequestBodySize.always,
+      hub: Hub(options..sendDefaultPii = sendDefaultPii),
+      maxRequestBodySize: MaxRequestBodySize.always,
     );
   }
 }


### PR DESCRIPTION
@ueman does this make sense?

This would allow extending the `DioEventProcessor`, for example to implement response data logging, and adding it manually via `options.addEventProcessor()`.